### PR TITLE
Remove non-existent component licenses

### DIFF
--- a/LICENSE-STM32CubeU5.md
+++ b/LICENSE-STM32CubeU5.md
@@ -1,28 +1,4 @@
 | Component                       | Copyright                                                          | License                                       |
 |:---------                       |:----------                                                         |:-------                                       |
-| Cortex-M CMSIS                  | ARM Limited                                                        | Apache License 2.0                            |
 | STM32U5xx CMSIS                 | ARM Limited - STMicroelectronics                                   | Apache License 2.0                            |                                               
 | STM32U5xx HAL                   | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| BSP STM32U575I-EV               | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| BSP STM32U5xx NUCLEO            | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| BSP B-U585I-IOT02A              | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| BSP Components                  | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| BSP MXCHIP                      | STMicroelectronics                                                 | SLA0044                                       |
-| Aure RTOS ThreadX               | Microsoft                                                          | Microsoft Software License for Azure RTOS     |
-| Aure RTOS NetXDuo               | Microsoft                                                          | Microsoft Software License for Azure RTOS     |
-| Aure RTOS FileX                 | Microsoft                                                          | Microsoft Software License for Azure RTOS     |
-| Aure RTOS LeveLX                | Microsoft                                                          | Microsoft Software License for Azure RTOS     |
-| Aure RTOS USBX                  | Microsoft                                                          | Microsoft Software License for Azure RTOS     |
-| STM32 TouchSensing Library      | STMicroelectronics                                                 | SLA0044                                       |
-| STM32 USBPD Core Library        | STMicroelectronics                                                 | SLA0044                                       |
-| STM32 USBPD Device Library      | STMicroelectronics                                                 | SLA0044                                       |
-| OpenBootloader                  | STMicroelectronics                                                 | SLA0044                                       |
-| Network Library                 | STMicroelectronics, ARM Limited                                    | SLA0044                                       |
-| mbed-crypto                     | Arm Limited (or its affiliates)                                    | Apache License 2.0                            |
-| mcuboot                         | Linaro Limited, Arm Limited (or its affiliates), JUUL Labs, Nordic Semiconductor ASA, Cypress Semiconductor Corporation,  Runtime Inc, Open Source Foundries Limited,  Intel Corporation,  Wind River Systems, Inc., The Linux Foundation and its contributors,  the fiat-crypto authors, Chris Morrison,  Kenneth MacKay | Apache License 2.0                            |
-| trustedfirmware                 | ARM Limited, Wind River Systems, Inc., Linaro Limited, Laurence Lundblade, The Linux Foundation, IETF Trust and the persons identified as the document authors                                                                                                                                                            | BSD 3-Clause                                  |
-| Utilities                       | STMicroelectronics                                                 | BSD 3-Clause                                  |
-| Utilities/LPBAM                 | STMicroelectronics                                                 | SLA0044                                       |
-| Applications projects           | STMicroelectronics                                                 | SLA0044                                       |   
-| Demonstrations projects         | STMicroelectronics                                                 | SLA0044                                       |   
-| Example Projects                | STMicroelectronics                                                 | BSD 3-Clause                                  |


### PR DESCRIPTION
A recent commit removed unnecessary code from this repo.

This commit updates the licenses file to only report licenses for code that is still present.
